### PR TITLE
expanderを外部のディレクトリからも呼べるようにする

### DIFF
--- a/expander.py
+++ b/expander.py
@@ -50,7 +50,7 @@ def main():
     """
     メイン関数
     """
-    lib_path = Path.cwd()
+    lib_path = Path(__file__).parent.resolve()
     basicConfig(
         format="%(asctime)s [%(levelname)s] %(message)s",
         datefmt="%H:%M:%S",


### PR DESCRIPTION
素晴らしいライブラリをありがとうございます!

解答提出時のことを考えると、外部ディレクトリからexpanderを呼べるとより便利だと思いました。

動作確認
```
% python ~/src/github.com/haruyama480/Nim-ACL/expander.py -s convolution_test.nim
16:35:12 [INFO] import src/atcoder/header.nim
16:35:12 [INFO] import src/atcoder/modint.nim
16:35:12 [INFO] import src/atcoder/generate_definitions.nim
16:35:12 [INFO] import src/atcoder/internal_math.nim
16:35:12 [INFO] import src/atcoder/convolution.nim
16:35:12 [INFO] already included src/atcoder/internal_math.nim, skip
16:35:12 [INFO] import src/atcoder/internal_bit.nim
16:35:12 [INFO] import src/atcoder/element_concepts.nim
16:35:12 [INFO] already included src/atcoder/modint.nim, skip

% nim cpp -r --verbosity:0 combined.nim
Hint: system [Processing]
Hint: widestrs [Processing]
Hint: io [Processing]
Hint: macros [Processing]
2 2
1 1
1 1
1 2 1
```

互換性確認
```
% python expander.py src/verify/convolution_test.nim 
16:36:40 [INFO] import src/atcoder/header.nim
16:36:40 [INFO] import src/atcoder/modint.nim
16:36:40 [INFO] import src/atcoder/generate_definitions.nim
16:36:40 [INFO] import src/atcoder/internal_math.nim
16:36:40 [INFO] import src/atcoder/convolution.nim
16:36:40 [INFO] already included src/atcoder/internal_math.nim, skip
16:36:40 [INFO] import src/atcoder/internal_bit.nim
16:36:40 [INFO] import src/atcoder/element_concepts.nim
16:36:40 [INFO] already included src/atcoder/modint.nim, skip
```