### PR TITLE
Fix DynamicModint SideEffect

### DIFF
--- a/src/atcoder/modint.nim
+++ b/src/atcoder/modint.nim
@@ -23,8 +23,9 @@ when not declared ATCODER_MODINT_HPP:
   import atcoder/internal_math
 
   proc getBarrett*[T:static[int]](t:typedesc[DynamicModInt[T]]):ptr Barrett =
-    var Barrett_of_DynamicModInt {.global.} = initBarrett(998244353.uint)
-    return Barrett_of_DynamicModInt.addr
+    {.cast(noSideEffect).}:
+      var Barrett_of_DynamicModInt {.global.} = initBarrett(998244353.uint)
+      return Barrett_of_DynamicModInt.addr
   
   proc getMod*[T:static[int]](t:typedesc[DynamicModInt[T]]):uint32 {.inline.} =
     (t.getBarrett)[].m.uint32

--- a/tests/test_modint.nim
+++ b/tests/test_modint.nim
@@ -1,5 +1,6 @@
 import atcoder/modint as modint_lib
 import std/math
+import std/sequtils
 import std/unittest
 
 static:
@@ -320,3 +321,7 @@ test "ModintTest, ConstructorStatic":
   var m:mint
   check 0 == m.val()
 
+test "ModintTest, DynamicModintSum":
+  type mint = modint
+  mint.setMod(998244353)
+  check 10 == newSeqWith(10, mint(1)).sum.val


### PR DESCRIPTION
`DynamicModint` に対して `std/math` の `sum` などの`{.noSideEffect.}` pragma がついておりかつ `+=` を呼ぶような関数が呼ばれると、コンパイルエラーとなる。
https://atcoder.jp/contests/abs/submissions/52161969

`getBarrett` が global 領域の変数のポインタにアクセスするのが問題だが、実際にはこれが書き換えられることはないので、 `{.cast(noSideEffect).}` で回避して問題ないと考える