### PR TITLE
Fix binary search

### DIFF
--- a/src/atcoder/extra/other/binary_search.nim
+++ b/src/atcoder/extra/other/binary_search.nim
@@ -5,7 +5,7 @@ when not declared ATCODER_BINARY_SEARCH_HPP:
     var (l, r) = (s.a - 1, s.b)
     if not f(r): return s.b + 1
     while r - l > 1:
-      let d = (r - l) shr 1
+      let d = cast[int]((cast[uint](r) - cast[uint](l)) shr 1)
       let m = l + d
       if f(m): r = m
       else: l = m
@@ -14,7 +14,7 @@ when not declared ATCODER_BINARY_SEARCH_HPP:
     var (l, r) = (s.a, s.b + 1)
     if not f(l): return s.a - 1
     while r - l > 1:
-      let d = (r - l) shr 1
+      let d = cast[int]((cast[uint](r) - cast[uint](l)) shr 1)
       let m = l + d
       if f(m): l = m
       else: r = m

--- a/src/atcoder/extra/other/binary_search.nim
+++ b/src/atcoder/extra/other/binary_search.nim
@@ -4,7 +4,7 @@ when not declared ATCODER_BINARY_SEARCH_HPP:
   proc minLeft*(f:proc(x:int):bool, s:Slice[int]):int =
     var (l, r) = (s.a - 1, s.b)
     if not f(r): return s.b + 1
-    while r - l > 1:
+    while r > l + 1:
       let d = cast[int]((cast[uint](r) - cast[uint](l)) shr 1)
       let m = l + d
       if f(m): r = m
@@ -13,7 +13,7 @@ when not declared ATCODER_BINARY_SEARCH_HPP:
   proc maxRight*(f:proc(x:int):bool, s:Slice[int]):int =
     var (l, r) = (s.a, s.b + 1)
     if not f(l): return s.a - 1
-    while r - l > 1:
+    while r - 1 > l:
       let d = cast[int]((cast[uint](r) - cast[uint](l)) shr 1)
       let m = l + d
       if f(m): l = m


### PR DESCRIPTION
l = -5×10^18, r = 7×10^18 といったときにオーバーフローするコードになっていたので修正